### PR TITLE
Add support for subrepository scanning and regex tag matching in regmaid policies

### DIFF
--- a/internal/regmaid/clean.go
+++ b/internal/regmaid/clean.go
@@ -21,11 +21,12 @@ var (
 )
 
 type PolicyResult struct {
-	Error     error
-	Policy    *Policy
-	Registry  *Registry
-	Manifests []Manifest
-	TotalTags int
+	Error      error
+	Policy     *Policy
+	Registry   *Registry
+	Manifests  []Manifest
+	Repository string
+	TotalTags  int
 }
 
 func ExecuteClean(ctx context.Context) error {
@@ -48,67 +49,79 @@ func ExecuteClean(ctx context.Context) error {
 
 	// Process policies
 	for _, policy := range cfg.Policies {
-		wg.Add(1)
 
-		go func() {
-			defer wg.Done()
+		reg := getRegistry(cfg, &policy)
 
-			reg := getRegistry(cfg, &policy)
+		var retention time.Duration
 
-			repo, _ := ref.New(fmt.Sprintf("%s/%s", reg.Host, policy.Repository))
+		if policy.Retention != "" {
+			duration, err := str2duration.ParseDuration(policy.Retention)
+			if err == nil {
+				retention = duration
+			}
+		}
 
-			var retention time.Duration
+		fmt.Printf("Processing policy %q...\n", policy.Name)
 
-			if policy.Retention != "" {
-				duration, err := str2duration.ParseDuration(policy.Retention)
-				if err == nil {
-					retention = duration
+		repos, err := maid.GetRepositories(ctx, reg.Host, policy.Repository)
+		if err != nil {
+			fmt.Printf("Error getting repositories for policy %q: %v\n", policy.Name, err)
+			return err
+		}
+
+		for _, repoName := range repos {
+			wg.Add(1)
+
+			go func(repoName string) {
+				defer wg.Done()
+
+				fmt.Printf("Processing repository %q\n", repoName)
+
+				repo, _ := ref.New(fmt.Sprintf("%s/%s", reg.Host, repoName))
+
+				total, manifests, err := maid.ScanRepository(ctx, repo.CommonName(), policy.Match, policy.Regex)
+
+				result := &PolicyResult{
+					TotalTags:  total,
+					Policy:     &policy,
+					Registry:   reg,
+					Manifests:  manifests,
+					Repository: repoName,
 				}
-			}
 
-			fmt.Printf("Processing policy %q...\n", policy.Name)
-
-			total, manifests, err := maid.ScanRepository(ctx, repo.CommonName(), policy.Match, policy.Regex)
-
-			result := &PolicyResult{
-				TotalTags: total,
-				Policy:    &policy,
-				Registry:  reg,
-				Manifests: manifests,
-			}
-
-			if err != nil {
-				result.Error = err
-			}
-
-			// Sort tags by age (ascending)
-			slices.SortFunc(result.Manifests, func(a, b Manifest) int {
-				return cmp.Compare(a.Age, b.Age)
-			})
-
-			// Always keep N newest tags
-			keep := min(result.Policy.Keep, len(result.Manifests))
-			result.Manifests = result.Manifests[keep:]
-
-			filtered := []Manifest{}
-
-			// Filter for tags after retention period
-			for _, m := range result.Manifests {
-				if m.Age >= retention {
-					filtered = append(filtered, m)
+				if err != nil {
+					result.Error = err
 				}
-			}
 
-			result.Manifests = filtered
+				// Sort tags by age (ascending)
+				slices.SortFunc(result.Manifests, func(a, b Manifest) int {
+					return cmp.Compare(a.Age, b.Age)
+				})
 
-			lock.Lock()
+				// Always keep N newest tags
+				keep := min(result.Policy.Keep, len(result.Manifests))
+				result.Manifests = result.Manifests[keep:]
 
-			results = append(results, result)
+				filtered := []Manifest{}
 
-			lock.Unlock()
+				// Filter for tags after retention period
+				for _, m := range result.Manifests {
+					if m.Age >= retention {
+						filtered = append(filtered, m)
+					}
+				}
 
-			fmt.Printf("Finished processing policy %q\n", policy.Name)
-		}()
+				result.Manifests = filtered
+
+				lock.Lock()
+
+				results = append(results, result)
+
+				lock.Unlock()
+			}(repoName)
+		}
+
+		fmt.Printf("Finished processing policy %q\n", policy.Name)
 	}
 
 	// Wait for all policies to finish processing
@@ -140,7 +153,7 @@ func ExecuteClean(ctx context.Context) error {
 			fmt.Printf("Policy %q found %d/%d tags eligible for deletion:\n", result.Policy.Name, len(result.Manifests), result.TotalTags)
 
 			for _, m := range result.Manifests {
-				fmt.Printf("%s (%s) (%dd)\n", m.Tag, m.Digest, int(m.Age.Hours()/24))
+				fmt.Printf("%s:%s (%s) (%dd)\n", result.Repository, m.Tag, m.Digest, int(m.Age.Hours()/24))
 			}
 		} else {
 
@@ -187,7 +200,7 @@ func ExecuteClean(ctx context.Context) error {
 
 			reg := getRegistry(cfg, result.Policy)
 
-			repo, _ := ref.New(fmt.Sprintf("%s/%s", reg.Host, result.Policy.Repository))
+			repo, _ := ref.New(fmt.Sprintf("%s/%s", reg.Host, result.Repository))
 
 			digestsMap := make(map[string]any)
 

--- a/internal/regmaid/clean.go
+++ b/internal/regmaid/clean.go
@@ -68,7 +68,7 @@ func ExecuteClean(ctx context.Context) error {
 
 			fmt.Printf("Processing policy %q...\n", policy.Name)
 
-			total, manifests, err := maid.ScanRepository(ctx, repo.CommonName(), policy.Match)
+			total, manifests, err := maid.ScanRepository(ctx, repo.CommonName(), policy.Match, policy.Regex)
 
 			result := &PolicyResult{
 				TotalTags: total,

--- a/internal/regmaid/config.go
+++ b/internal/regmaid/config.go
@@ -35,6 +35,7 @@ type Policy struct {
 	Registry   string `yaml:"registry"`
 	Repository string `yaml:"repository"`
 	Match      string `yaml:"match"`
+	Regex	   bool   `yaml:"regex"`
 	Keep       int    `yaml:"keep"`
 	Retention  string `yaml:"retention"`
 	Force      bool   `yaml:"force"`

--- a/internal/regmaid/config.go
+++ b/internal/regmaid/config.go
@@ -31,14 +31,14 @@ type Registry struct {
 }
 
 type Policy struct {
-	Name       string `yaml:"name"`
-	Registry   string `yaml:"registry"`
-	Repository string `yaml:"repository"`
-	Match      string `yaml:"match"`
-	Regex	   bool   `yaml:"regex"`
-	Keep       int    `yaml:"keep"`
-	Retention  string `yaml:"retention"`
-	Force      bool   `yaml:"force"`
+	Name        string `yaml:"name"`
+	Registry    string `yaml:"registry"`
+	Repository  string `yaml:"repository"`
+	Match       string `yaml:"match"`
+	Regex	    bool   `yaml:"regex"`
+	Keep        int    `yaml:"keep"`
+	Retention   string `yaml:"retention"`
+	Force       bool   `yaml:"force"`
 }
 
 func LoadConfig(path string) (*Config, error) {

--- a/internal/regmaid/regmaid.go
+++ b/internal/regmaid/regmaid.go
@@ -69,6 +69,33 @@ func (r *RegMaid) DeleteManifests(ctx context.Context, repo string, digests []st
 	return nil
 }
 
+// Get a list of all repositories matching with the specified match.
+func (r *RegMaid) GetRepositories(ctx context.Context, host string, match string) ([]string, error) {
+    rl, err := r.client.RepoList(ctx, host)
+    if err != nil {
+        return nil, fmt.Errorf("error listing repositories for host %s: %v", host, err)
+    }
+
+    repos, err := rl.GetRepos()
+    if err != nil {
+        return nil, fmt.Errorf("error extracting repositories for host %s: %v", host, err)
+    }
+
+	regex, err := getRegex(match, false)
+	if err != nil {
+		return nil, err
+	}
+
+    filteredRepos := make([]string, 0)
+    for _, repo := range repos {
+        if regex.MatchString(repo) {
+            filteredRepos = append(filteredRepos, repo)
+        }
+    }
+
+	return filteredRepos, nil
+}
+
 // Scans all tagged manifests of the repository and returns the ones matching the specified filter.
 func (r *RegMaid) ScanRepository(ctx context.Context, repo string, match string, isRegex bool) (int, []Manifest, error) {
 	repoRef, err := ref.New(repo)

--- a/internal/regmaid/regmaid.go
+++ b/internal/regmaid/regmaid.go
@@ -70,14 +70,14 @@ func (r *RegMaid) DeleteManifests(ctx context.Context, repo string, digests []st
 }
 
 // Scans all tagged manifests of the repository and returns the ones matching the specified filter.
-func (r *RegMaid) ScanRepository(ctx context.Context, repo string, match string) (int, []Manifest, error) {
+func (r *RegMaid) ScanRepository(ctx context.Context, repo string, match string, isRegex bool) (int, []Manifest, error) {
 	repoRef, err := ref.New(repo)
 	if err != nil {
 
 		return 0, nil, err
 	}
 
-	regex, err := getRegex(match)
+	regex, err := getRegex(match, isRegex)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -159,14 +159,18 @@ func (r *RegMaid) ScanRepository(ctx context.Context, repo string, match string)
 	return totalTags, tags, nil
 }
 
-func getRegex(match string) (*regexp.Regexp, error) {
+func getRegex(match string, isRegex bool) (*regexp.Regexp, error) {
 	if match == "" {
+		isRegex = false
 		match = "*"
 	}
-
-	regexStr := "^" + regexp.QuoteMeta(match) + "$"
-	regexStr = strings.ReplaceAll(regexStr, "\\*", ".*")
-	regexStr = strings.ReplaceAll(regexStr, "\\?", ".")
-
-	return regexp.Compile(regexStr)
+	
+	if isRegex {
+		return regexp.Compile(match)
+	} else {
+		regexStr := "^" + regexp.QuoteMeta(match) + "$"
+		regexStr = strings.ReplaceAll(regexStr, "\\*", ".*")
+		regexStr = strings.ReplaceAll(regexStr, "\\?", ".")
+		return regexp.Compile(regexStr)
+	}
 }

--- a/regmaid.yaml
+++ b/regmaid.yaml
@@ -31,7 +31,7 @@ registries:
 policies:
   - name: dev-images # Name of the policy
     registry: registry # Name of the registry this policy applies to
-    repository: my-repository # Name of the repository this policy applies to
+    repository: my-repository # Name of the repository this policy applies to (supports wildcards)
     match: *-dev # Wildcard expression for matching tags this policy applies to
     regex: false # Whether the match is a regex (false by default)
     retention: 30d # Remove tags older than 30 days

--- a/regmaid.yaml
+++ b/regmaid.yaml
@@ -33,6 +33,7 @@ policies:
     registry: registry # Name of the registry this policy applies to
     repository: my-repository # Name of the repository this policy applies to
     match: *-dev # Wildcard expression for matching tags this policy applies to
+    regex: false # Whether the match is a regex (false by default)
     retention: 30d # Remove tags older than 30 days
     keep: 10 # Always keep the 10 newest tags (minimum 1 if 'force' is not enabled)
     force: false # If enabled, allows 'keep' value of 0, which could delete all tags


### PR DESCRIPTION
This PR introduces two main enhancements:

Subrepository Scanning:
Regmaid can now look for subrepositories within the configured repository when the hasSubrepos flag is enabled in a policy. This allows for more flexible and comprehensive repository management.

Regex Tag Matching:
Policies can now specify a regular expression for tag matching by setting the regex option to true. This enables advanced tag selection beyond simple wildcard patterns.